### PR TITLE
Fix a bug with keys

### DIFF
--- a/src/main/java/com/rebane2001/livemessage/gui/LivemessageGui.java
+++ b/src/main/java/com/rebane2001/livemessage/gui/LivemessageGui.java
@@ -7,6 +7,7 @@ import com.rebane2001.livemessage.util.LiveProfileCache;
 import com.rebane2001.livemessage.util.LivemessageUtil;
 import net.minecraft.client.gui.*;
 import net.minecraft.client.renderer.GlStateManager;
+import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.GL11;
 
@@ -99,6 +100,8 @@ public class LivemessageGui extends GuiScreen {
     }
 
     public void initGui() {
+        Keyboard.enableRepeatEvents(true);
+
         this.buttonList.clear();
 
         setScl();
@@ -107,6 +110,11 @@ public class LivemessageGui extends GuiScreen {
 
         if (liveWindows.isEmpty())
             liveWindows.add(new ManeWindow());
+    }
+
+    @Override
+    public void onGuiClosed() {
+        Keyboard.enableRepeatEvents(false);
     }
 
     // Safe chatwindow adding

--- a/src/main/java/com/rebane2001/livemessage/util/LivemessageUtil.java
+++ b/src/main/java/com/rebane2001/livemessage/util/LivemessageUtil.java
@@ -19,6 +19,8 @@ import java.util.regex.Pattern;
 public class LivemessageUtil {
 
     public static final Pattern fromPatterns[] = {
+            Pattern.compile("^From (\\w{3,16}): (.*)"),
+            Pattern.compile("^from (\\w{3,16}): (.*)"),
             Pattern.compile("^(\\w{3,16}) whispers: (.*)"),
             Pattern.compile("^\\[(\\w{3,16}) -> me\\] (.*)"),
             Pattern.compile("^(\\w{3,16}) whispers to you: (.*)")


### PR DESCRIPTION
The GUIs don't have repeat key events enabled, so it makes typing, especially deleting more difficult. This was a very simple fix.

Also added a few patterns to regex in fromPatterns, I know it's planned to have them be customizable in the future, but I still wanted to add these to match their counterparts in the toPatterns