### PR TITLE
Replacing the past names functionality with a straight forward name by UUID lookup. 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 mod_id = livemessage
 mod_name = Livemessage
 mod_group = com.rebane2001
-mod_version = 1.1.2
+mod_version = 1.1.3
 mod_author = ["rebane2001"]
 mod_description = A Minecraft DM manager
 

--- a/src/main/java/com/rebane2001/livemessage/gui/ChatWindow.java
+++ b/src/main/java/com/rebane2001/livemessage/gui/ChatWindow.java
@@ -32,8 +32,6 @@ public class ChatWindow extends LiveWindow {
     boolean valid;
 
     LiveProfile liveProfile;
-    boolean pastNamesB = false;
-    int longestPastName = 80;
     String msgString;
 
     final int scrollBarWidth = 10;
@@ -267,20 +265,10 @@ public class ChatWindow extends LiveWindow {
         if (mouseInRect(0, 0, w, h, mouseX, mouseY))
             markAsRead();
         liveButtons.forEach(LiveButton::runIfClicked);
-        if (pastNamesB) {
-            pastNamesB = false;
-            return;
-        }
         if (mouseInRect(chatBoxX + w - 10 - scrollBarWidth, chatBoxY, scrollBarWidth, h - (chatBoxY + 10 + chatBoxSize), mouseX, mouseY) && chatHistory.size() > 1) {
             scrolling = true;
             dragY = mouseY - (this.y + chatBoxY + (h - (chatBoxY + 10 + chatBoxSize + scrollBarHeight)) * chatScrollPosition / (chatHistory.size() - 1));
         }
-        longestPastName = Math.max(fontRenderer.getStringWidth(liveProfile.username), longestPastName);
-        if (mouseX > x + 40 && mouseX < x + 40 + longestPastName + 4 && mouseY > y + titlebarHeight + 4 && mouseY < y + titlebarHeight + 4 + 12) {
-            pastNamesB = true;
-            return;
-        }
-
         super.mouseClicked(mouseX, mouseY, mouseButton);
     }
 
@@ -449,23 +437,6 @@ public class ChatWindow extends LiveWindow {
 
         drawChatHistory(chatBoxX, chatBoxY, getSingleRGB(255), fgColor);
         drawProfilePic(5, titlebarHeight + 5);
-
-        // Namehistory
-        if (pastNamesB) {
-            if (liveProfile.pastNames == null) {
-                drawRect(40, titlebarHeight + 3, longestPastName + 4, 12, getSingleRGB(128));
-                liveProfile = LiveProfileCache.forceloadNameHistory(liveProfile);
-            } else {
-                drawRect(40, titlebarHeight + 3, longestPastName + 4, 12 * liveProfile.pastNames.size(), fgColor);
-                int i = 0;
-                for (String name : liveProfile.pastNames) {
-                    if (lastMouseX > x + 40 && lastMouseX < x + 40 + longestPastName + 4 && lastMouseY > y + titlebarHeight + 3 + 12 * i && lastMouseY < y + titlebarHeight + 4 + 12 + 12 * i)
-                        drawRect(40, titlebarHeight + 3 + 12 * i, longestPastName + 4, 12, getRGBA(255, 255, 255, 64));
-                    fontRenderer.drawString(name, 42, titlebarHeight + 5 + 12 * i, getSingleRGB(255));
-                    i++;
-                }
-            }
-        }
 
         // Tooltips
         liveButtons.forEach(LiveButton::drawTooltips);


### PR DESCRIPTION
The previously used endpoint `GET https://api.mojang.com/user/profiles/<uuid>/names` has been deprecated and removed by Mojang on September 13th, 2022, as documented here: https://help.minecraft.net/hc/en-us/articles/8969841895693-Username-History-API-Removal-FAQ

This API endpoint was previously used by the Livemessage DM manager to retrieve the current, and past names of other players.
The removal of this endpoint caused the application to encounter an FileNotFoundException, resulting in all player UUIDs being discarded as 'bad UUIDs'.

This pull request replaces the past name functionality with a simple name by UUID lookup through a still supported Mojang API endpoint. This restores the application's ability to show and retrieve the current names of players, but names past name information no longer supported from here on out. 